### PR TITLE
feat: add `--scope-symlinks` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 [![Build Status](https://github.com/restic/restic/workflows/test/badge.svg)](https://github.com/restic/restic/actions?query=workflow%3Atest)
 [![Go Report Card](https://goreportcard.com/badge/github.com/restic/restic)](https://goreportcard.com/report/github.com/restic/restic)
 
+# Fork Information
+
+This fork adds a new flag to `backup` and `restore` actions - `--scope-symlinks` - which allows skipping symlinks that are targeting files outside of the specified path.
+Example usage:
+
+    $ restic --repo /tmp/backup backup /var/foo --scope-symlinks=/var/foo
+    $ restic --repo /tmp/backup restore 674eb8ba -t / --scope-symlinks=/var/foo
+
 # Introduction
 
 restic is a backup program that is fast, efficient and secure. It supports the three major operating systems (Linux, macOS, Windows) and a few smaller ones (FreeBSD, OpenBSD).

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -73,6 +74,8 @@ type RestoreOptions struct {
 	Include            []string
 	InsensitiveInclude []string
 	Target             string
+	ScopeSymlinks      string
+
 	restic.SnapshotFilter
 	Sparse bool
 	Verify bool
@@ -89,6 +92,7 @@ func init() {
 	flags.StringArrayVarP(&restoreOptions.Include, "include", "i", nil, "include a `pattern`, exclude everything else (can be specified multiple times)")
 	flags.StringArrayVar(&restoreOptions.InsensitiveInclude, "iinclude", nil, "same as --include but ignores the casing of `pattern`")
 	flags.StringVarP(&restoreOptions.Target, "target", "t", "", "directory to extract data to")
+	flags.StringVar(&restoreOptions.ScopeSymlinks, "scope-symlinks", "", "do not extract symlinks that are targeting files outside this path")
 
 	initSingleSnapshotFilter(flags, &restoreOptions.SnapshotFilter)
 	flags.BoolVar(&restoreOptions.Sparse, "sparse", false, "restore files as sparse")
@@ -100,6 +104,7 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 
 	hasExcludes := len(opts.Exclude) > 0 || len(opts.InsensitiveExclude) > 0
 	hasIncludes := len(opts.Include) > 0 || len(opts.InsensitiveInclude) > 0
+	hasSymlinkScope := opts.ScopeSymlinks != ""
 
 	// Validate provided patterns
 	if len(opts.Exclude) > 0 {
@@ -244,10 +249,65 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 		return selectedForRestore, childMayBeSelected
 	}
 
+	symlinkScope := opts.ScopeSymlinks
+	selectSymlinkScopeFilter := func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
+		childMayBeSelected = node.Type == "dir"
+		if node.Type != "symlink" {
+			return true, childMayBeSelected
+		}
+
+		// node.LinkTarget can be absolute (e.g. /var/test/target) or:
+		// 1. relative, with .. somewhere in the path (e.g. /var/test/target/next/..)
+		// 2. relative, starting with . (e.g. ./test/target)
+		//
+		// Need to clean node.LinkTarget to remove abundant relative path links:
+		//   /var/test/target/next/.. -> /var/test/target
+		//   ./test/target -> test/target
+		//
+		// The path can still be relative after Clean (e.g. ./var/../../target -> ../target)
+		// so we need to convert it to absolute with destination path in mind.
+		// To do this, select the top destination path element that is not a file
+		// and append the target to it:
+		//   /restore/test/symlink -> /restore/test/../target
+		//
+		// and then run Clean again to remove remaining relative path links:
+		//   /restore/test/../target -> /restore/target
+		target := filepath.Clean(node.LinkTarget)
+		if !filepath.IsAbs(target) {
+			target = filepath.Clean(filepath.Join(filepath.Dir(dstpath), target))
+		}
+
+		target, err := filepath.EvalSymlinks(target)
+		if err != nil {
+			msg.E("error for eval symlink: %v", err)
+			// reject symlink if we cannot determine its target
+			return false, childMayBeSelected
+		}
+
+		return strings.HasPrefix(target, symlinkScope), childMayBeSelected
+	}
+
+	selectFilters := []func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool){}
 	if hasExcludes {
-		res.SelectFilter = selectExcludeFilter
+		selectFilters = append(selectFilters, selectExcludeFilter)
 	} else if hasIncludes {
-		res.SelectFilter = selectIncludeFilter
+		selectFilters = append(selectFilters, selectIncludeFilter)
+	}
+
+	if hasSymlinkScope {
+		selectFilters = append(selectFilters, selectSymlinkScopeFilter)
+	}
+
+	if len(selectFilters) > 0 {
+		res.SelectFilter = func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
+			for _, filter := range selectFilters {
+				selectedForRestore, childMayBeSelected = filter(item, dstpath, node)
+				if !selectedForRestore {
+					break
+				}
+			}
+			return selectedForRestore, childMayBeSelected
+		}
 	}
 
 	if !gopts.JSON {

--- a/cmd/restic/exclude.go
+++ b/cmd/restic/exclude.go
@@ -385,6 +385,38 @@ func rejectBySize(maxSizeStr string) (RejectFunc, error) {
 	}, nil
 }
 
+// rejectSymlinksOutsideScope rejects symlinks that target
+// files outside of the specified path.
+func rejectSymlinksOutsideScope(scopePath string) (RejectFunc, error) {
+	var err error
+	if !filepath.IsAbs(scopePath) {
+		scopePath, err = filepath.Abs(scopePath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return func(item string, fi os.FileInfo) bool {
+		if fi.Mode()&os.ModeSymlink != os.ModeSymlink {
+			return false
+		}
+
+		target, err := filepath.EvalSymlinks(item)
+		if err != nil {
+			// reject symlink if we cannot determine the target
+			debug.Log("could not eval target of symlink: %s", item)
+			return true
+		}
+
+		if !strings.HasPrefix(target, scopePath) {
+			debug.Log("target of symlink %s is outside of path: %s", item, scopePath)
+			return true
+		}
+
+		return false
+	}, nil
+}
+
 // readExcludePatternsFromFiles reads all exclude files and returns the list of
 // exclude patterns. For each line, leading and trailing white space is removed
 // and comment lines are ignored. For each remaining pattern, environment

--- a/cmd/restic/exclude_test.go
+++ b/cmd/restic/exclude_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/restic/restic/internal/test"
@@ -260,6 +261,104 @@ func TestIsExcludedByFileSize(t *testing.T) {
 
 	// compare whether the walk gave the expected values for the test cases
 	for _, f := range files {
+		p := filepath.Join(tempDir, filepath.FromSlash(f.path))
+		if m[p] != f.incl {
+			t.Errorf("inclusion status of %s is wrong: want %v, got %v", f.path, f.incl, m[p])
+		}
+	}
+}
+
+// TestIsExcludedBySymlinkScope is for testing the instance of
+// --scope-symlinks parameter
+func TestIsExcludedBySymlinkScope(t *testing.T) {
+	tempDir := test.TempDir(t)
+
+	scopePath := filepath.Join(tempDir, "foodir")
+
+	var errs []error
+	errs = append(errs, os.MkdirAll(filepath.Dir(scopePath), 0700))
+
+	// Create some files in a temporary directory.
+	files := []struct {
+		path string
+		incl bool
+	}{
+		{"42", true},
+		{"foodir/foo", true},
+		{"foodir/foosub/underfoo", true},
+		{"bardir/bar", true},
+		{"bardir/barsub/underbar", true},
+	}
+	for _, f := range files {
+		// create directories first, then the file
+		p := filepath.Join(tempDir, filepath.FromSlash(f.path))
+		errs = append(errs, os.MkdirAll(filepath.Dir(p), 0700))
+		file, err := os.Create(p)
+		errs = append(errs, err)
+		errs = append(errs, file.Close())
+	}
+
+	joinFn := func(elem ...string) string {
+		res := ""
+		sep := string(filepath.Separator)
+		for _, e := range elem {
+			res += sep + filepath.FromSlash(e)
+		}
+		return strings.TrimPrefix(res, sep)
+	}
+
+	// Create the symlinks, some of them need to be relative
+	// so can't use filepath.Join as it makes them absolute.
+	symlinks := []struct {
+		path       string
+		targetPath string
+		incl       bool
+	}{
+		{"123", joinFn(tempDir, "foodir/foo"), true},
+		{"1234", "..", false},
+
+		{"foodir/insidefoo", joinFn(tempDir, "foodir/foosub/underfoo"), true},
+		{"foodir/outsidefoo2", joinFn(tempDir, "foodir/.."), false},
+		{"foodir/outsidefoo3", "..", false},
+		{"foodir/outsidefoo4", tempDir, false},
+
+		{"bardir/insidefoo", joinFn(tempDir, "foodir/foo"), true},
+		{"bardir/insidebar", joinFn(tempDir, "bardir"), false},
+		{"bardir/outsidebar", joinFn(tempDir, "bardir/../foodir/insidefoo"), true},
+	}
+	for _, s := range symlinks {
+		path := filepath.Join(tempDir, filepath.FromSlash(s.path))
+		errs = append(errs, os.Symlink(s.targetPath, path))
+	}
+
+	test.OKs(t, errs) // see if anything went wrong during the creation
+
+	scopePath, err := filepath.EvalSymlinks(scopePath)
+	test.OK(t, err)
+
+	// create rejection function
+	scopeExclude, _ := rejectSymlinksOutsideScope(scopePath)
+
+	// To mock the archiver scanning walk, we create filepath.WalkFn
+	// that tests against the rejection function and stores
+	// the result in a map that we can test against later.
+	m := make(map[string]bool)
+	walk := func(p string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		excluded := scopeExclude(p, fi)
+		// the log message helps debugging in case the test fails
+		t.Logf("%q: symlink:%t; excluded:%v", p, fi.Mode()&os.ModeSymlink == os.ModeSymlink, excluded)
+		m[p] = !excluded
+		return nil
+	}
+	// walk through the temporary file and check the error
+	test.OK(t, filepath.Walk(tempDir, walk))
+
+	// compare whether the walk gave the expected values for the test cases
+	for _, f := range symlinks {
 		p := filepath.Join(tempDir, filepath.FromSlash(f.path))
 		if m[p] != f.incl {
 			t.Errorf("inclusion status of %s is wrong: want %v, got %v", f.path, f.incl, m[p])

--- a/cmd/restic/integration_helpers_test.go
+++ b/cmd/restic/integration_helpers_test.go
@@ -343,6 +343,16 @@ func testFileSize(filename string, size int64) error {
 	return nil
 }
 
+func testFileExists(filename string) (bool, error) {
+	if _, err := os.Stat(filename); err == nil {
+		return true, nil
+	} else if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	} else {
+		return false, err
+	}
+}
+
 func withRestoreGlobalOptions(inner func() error) error {
 	gopts := globalOptions
 	defer func() {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR adds --scope-symlinks to restore and backup commands. This flag allows excluding symlink files, which target files outside of the provided path, to be excluded from being backuped/restored.