### PR TITLE
fix: eval paths of all files on backup with symlink scope

### DIFF
--- a/cmd/restic/exclude.go
+++ b/cmd/restic/exclude.go
@@ -397,19 +397,15 @@ func rejectSymlinksOutsideScope(scopePath string) (RejectFunc, error) {
 	}
 
 	return func(item string, fi os.FileInfo) bool {
-		if fi.Mode()&os.ModeSymlink != os.ModeSymlink {
-			return false
-		}
-
 		target, err := filepath.EvalSymlinks(item)
 		if err != nil {
 			// reject symlink if we cannot determine the target
-			debug.Log("could not eval target of symlink: %s", item)
+			debug.Log("could not eval symlinks: %s", item)
 			return true
 		}
 
 		if !strings.HasPrefix(target, scopePath) {
-			debug.Log("target of symlink %s is outside of path: %s", item, scopePath)
+			debug.Log("eval path of %s (%s) is outside of scope: %s", item, target, scopePath)
 			return true
 		}
 

--- a/cmd/restic/exclude_test.go
+++ b/cmd/restic/exclude_test.go
@@ -316,6 +316,7 @@ func TestIsExcludedBySymlinkScope(t *testing.T) {
 	}{
 		{"123", joinFn(tempDir, "foodir/foo"), true},
 		{"1234", "..", false},
+		{"12345", "../..", false},
 
 		{"foodir/insidefoo", joinFn(tempDir, "foodir/foosub/underfoo"), true},
 		{"foodir/outsidefoo2", joinFn(tempDir, "foodir/.."), false},
@@ -338,6 +339,17 @@ func TestIsExcludedBySymlinkScope(t *testing.T) {
 
 	// create rejection function
 	scopeExclude, _ := rejectSymlinksOutsideScope(scopePath)
+
+	// test a case when the file itself is not a symlink
+	// but it still should be excluded
+	symlinkedPath := filepath.Join(tempDir, "12345", "T")
+	fi, err := os.Lstat(symlinkedPath)
+	test.OK(t, err)
+
+	excluded := scopeExclude(symlinkedPath, fi)
+	if !excluded {
+		t.Errorf("inclusion status of %s is wrong: want %v, got %v", symlinkedPath, false, true)
+	}
 
 	// To mock the archiver scanning walk, we create filepath.WalkFn
 	// that tests against the rejection function and stores


### PR DESCRIPTION
Eval the paths of all files when creating a backup with symlink scope option set.