### PR TITLE
feat: check restore destination scope

### DIFF
--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -252,8 +253,25 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 	symlinkScope := opts.ScopeSymlinks
 	selectSymlinkScopeFilter := func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
 		childMayBeSelected = node.Type == "dir"
-		if node.Type != "symlink" {
-			return true, childMayBeSelected
+
+		dstdir := filepath.Dir(dstpath)
+		// if dstdir already exists eval any symlinks it may contain
+		// and check if the path diverges from the scope
+		if _, err := os.Stat(dstdir); err == nil || !os.IsNotExist(err) {
+			evaldstdir, err := filepath.EvalSymlinks(dstdir)
+			if err != nil {
+				msg.E("error for destination eval symlink: %v", err)
+				return false, childMayBeSelected
+			}
+
+			if evaldstdir != dstdir {
+				if !strings.HasPrefix(evaldstdir, symlinkScope) && !strings.HasPrefix(symlinkScope, evaldstdir) {
+					debug.Log("destination dir %s is a outside scope %s", evaldstdir, symlinkScope)
+					return false, childMayBeSelected
+				}
+			}
+
+			dstdir = evaldstdir
 		}
 
 		// node.LinkTarget can be absolute (e.g. /var/test/target) or:
@@ -272,19 +290,25 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 		//
 		// and then run Clean again to remove remaining relative path links:
 		//   /restore/test/../target -> /restore/target
-		target := filepath.Clean(node.LinkTarget)
-		if !filepath.IsAbs(target) {
-			target = filepath.Clean(filepath.Join(filepath.Dir(dstpath), target))
+		if node.Type == "symlink" {
+			target := filepath.Clean(node.LinkTarget)
+			if !filepath.IsAbs(target) {
+				target = filepath.Clean(filepath.Join(dstdir, target))
+			}
+
+			if !strings.HasPrefix(target, symlinkScope) {
+				debug.Log("item %s is a symlink to %s which is outside of scope %s", item, target, symlinkScope)
+				return false, childMayBeSelected
+			}
+		} else {
+			target := filepath.Join(dstdir, filepath.Base(dstpath))
+			if !strings.HasPrefix(target, symlinkScope) && !strings.HasPrefix(symlinkScope, target) {
+				debug.Log("item %s leads to %s which is outside of scope %s", item, target, symlinkScope)
+				return false, childMayBeSelected
+			}
 		}
 
-		target, err := filepath.EvalSymlinks(target)
-		if err != nil {
-			msg.E("error for eval symlink: %v", err)
-			// reject symlink if we cannot determine its target
-			return false, childMayBeSelected
-		}
-
-		return strings.HasPrefix(target, symlinkScope), childMayBeSelected
+		return true, childMayBeSelected
 	}
 
 	selectFilters := []func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool){}


### PR DESCRIPTION
Makes `--scope-symlinks` on `restore` to also check the destination dir, not only the file that is being restored.